### PR TITLE
Adds support for AMD syntax when calling define()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@
 
 ## Introduction
 
-This tiny library provides a way to organize your client-side scripts in CommonJs style.
-It only implements minimum features that required to work and nothing more.
-It also detects circular dependency and throws error. The behaviour is differ from NodeJs
-while NodeJs tries to return uninitialized exports object when resolving circular dependency.
+This tiny library provides a way to organize your client-side scripts in CommonJs style. It only implements minimum features that required to work and nothing more. It also detects circular dependency and throws error. The behaviour is different from NodeJs while NodeJs tries to return uninitialized exports object when resolving circular dependency.
 
 **Example:**
 
@@ -70,6 +67,20 @@ define('app', function(require, module, exports) {
 });
 
 require('app');
+```
+
+## Using AMD syntax
+
+```js
+define('module1', ['exports'], function(exports) {
+  exports.value = 10;
+});
+
+define('module2', ['module1'], function(module1) {
+  return module1.value * 2;
+})
+
+console.log(require('module2')); // 20
 ```
 
 ## Testing
@@ -169,17 +180,31 @@ define('bar', function() {
 
 ## API
 
-### define
+### define#CJS
 
 ```js
 define(id, callback)
 ```
 
-Define a module.
+Define a module using Simplified CommonJS Wrapper syntax.
 
 * **id** must be string and unique
 * **callback**: `function(require, module, exports)`
 
+
+### define#AMD
+
+```js
+define(id, dependencies, callback)
+```
+
+Define a module using Asynchronous Module Definition syntax.
+
+* **id** must be string and unique
+* **dependencies** must be an array of module names as strings
+* **callback**: `function(module1, module2, ...)` that returns the module interface
+
+The special module `exports` is supported as a dependency to expose the module's interface.
 
 ### require
 

--- a/min-require.js
+++ b/min-require.js
@@ -11,13 +11,28 @@
   }
 
   // define(id, function(require, module, exports))
-  function define(id, callback) {
+  // or
+  // define(id, [dep1, ...], function (module1, ...))
+  function define(id, deps, callback) {
     if (typeof id !== 'string' || id === '') throw new Error('invalid module id ' + id);
     if (funcs[id]) throw new Error('dupicated module id ' + id);
+    
+    if (typeof deps === 'function') {
+      funcs[id] = deps; // callback
+      return;
+    } 
+
     if (typeof callback !== 'function') throw new Error('invalid module function');
 
-    funcs[id] = callback;
+    funcs[id] = function (require, module, exports) {
+      return callback.apply(this, deps.map(function (dep) {
+        if (dep === 'exports') return exports;
+        return require(dep);
+      }));
+    }
   }
+
+  define.amd = {};
 
   function stubRequire(stub) {
     return function (id) {
@@ -36,14 +51,14 @@
     if (stack.indexOf(id) >= 0) throw new Error('circular: ' + stack.join(', '));
     if (stub) {
       m = { id: id, exports: {} };
-      funcs[id](stubRequire(stub), m, m.exports);
+      m.exports = funcs[id](stubRequire(stub), m, m.exports) || m.exports;
       return m.exports;
     }
     if (modules[id]) return modules[id].exports;
 
-    m = modules[id] = { id: id, exports: {} };
     stack.push(id);
-    funcs[id](require, m, m.exports);
+    m = modules[id] = { id: id, exports: {} };
+    m.exports = funcs[id](require, m, m.exports) || m.exports;
     stack.pop();
 
     return m.exports;

--- a/specs/min-requires-spec.js
+++ b/specs/min-requires-spec.js
@@ -76,7 +76,6 @@ describe('min-require', function () {
     expect(function () {
       require('C');
     }).toThrowError('circular: C, A, B');
-
   });
 
   it('should stub out the dependencies if require is called with stub object', function () {
@@ -106,5 +105,34 @@ describe('min-require', function () {
     });
 
     expect(SUT.getName()).toEqual('BravoModuleOnStubAlphaModule');
+  });
+
+  it('should inject dependencies using AMD style', function () {
+    var testValue1,
+        testValue2;
+
+    define('A', ['exports'], function (exports) {
+      exports.A = 'A';
+      exports[10] = 20;
+    });
+
+    define('B', ['A'], function (A) {
+      return 'B require ' + A.A;
+    });
+
+    define('C', ['A', 'B'], function (A, B) {
+      testValue1 = A[10];
+      testValue2 = B;
+    });
+
+    require('C');
+
+    expect(testValue1).toEqual(20);
+    expect(testValue2).toEqual('B require A');
+    
+    expect(require('B')).toEqual('B require A');
+
+    expect(require('A').A).toEqual('A');
+    expect(require('A')[10]).toEqual(20);
   });
 });


### PR DESCRIPTION
Current implementation only supports defining modules as `define(id, function(require, module, exports))`. In addition, UMD (and most?) loaders look for the property `define.amd` to actually use the AMD way instead of just creating a browser global variable. This makes using `min-require` with standard libraries and UMD loaders difficult.

This PR includes the definition of the `define.amd` property to trigger the AMD way of defining library modules and to correctly support most of them, including the ones that load using UMD, the `define(id, [dep1, dep2, ...], function (module1, module2, ...))` call format was implemented. When a module is defined in that way, it can expose its interface requiring the special module `exports` in the dependencies array or by returning the interface object.

Tests added and `README.md` updated with examples and API.
